### PR TITLE
Remove node-github dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "eslint-plugin-qunit": "^7.2.0",
     "fastboot": "^3.2.0-beta.5",
     "git-repo-info": "^2.1.1",
-    "github": "https://github.com/mikedeboer/node-github#ca90bf27d5820812c3b76908189d666446ed97cd",
     "jsdom": "^16.7.0",
     "loader.js": "^4.7.0",
     "ncp": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7767,12 +7767,6 @@ git-repo-info@^2.1.1:
   resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-2.1.1.tgz#220ffed8cbae74ef8a80e3052f2ccb5179aed058"
   integrity sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==
 
-"github@https://github.com/mikedeboer/node-github#ca90bf27d5820812c3b76908189d666446ed97cd":
-  version "0.2.3"
-  resolved "https://github.com/mikedeboer/node-github#ca90bf27d5820812c3b76908189d666446ed97cd"
-  dependencies:
-    mime "^1.2.11"
-
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -9555,7 +9549,7 @@ mime-types@^2.1.12, mime-types@^2.1.18, mime-types@^2.1.26, mime-types@^2.1.27, 
   dependencies:
     mime-db "1.50.0"
 
-mime@1.6.0, mime@^1.2.11:
+mime@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==


### PR DESCRIPTION
# Context

The `node-github` repo has been renamed `oktokit` and the reference to the locked commit in the package.json file does not exist anymore.

I've removed the dependency because I don't believe it's actually needed anymore.